### PR TITLE
chore: configure prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+public/
+build/
+.next/
+.out/
+pnpm-lock.yaml

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -5,6 +5,7 @@ import { includeIgnoreFile } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
 import eslintJs from '@eslint/js';
 import { defineConfig } from 'eslint/config';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -37,6 +38,7 @@ const eslintConfig = defineConfig([
   {
     files: ['src/**/*.{js,jsx,ts,tsx}'],
   },
+  eslintConfigPrettier,
   ...compat.config({
     extends: ['eslint:recommended', 'next/core-web-vitals', 'next/typescript'],
   }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "website",
   "version": "1.0.0",
+  "type": "module",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.10.0",
@@ -9,7 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "lint:fix": "next lint --fix"
+    "lint:fix": "next lint --fix",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "next": "^15.3.2",
@@ -24,6 +26,7 @@
     "eslint": "^9.26.0",
     "eslint-config-next": "^15.3.2",
     "jiti": "^2.4.2",
+    "prettier": "^3.5.3",
     "typescript": "^5.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^19.1.3",
     "eslint": "^9.26.0",
     "eslint-config-next": "^15.3.2",
+    "eslint-config-prettier": "^10.1.5",
     "jiti": "^2.4.2",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       jiti:
         specifier: ^2.4.2
         version: 2.4.2
+      prettier:
+        specifier: ^3.5.3
+        version: 3.5.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1410,6 +1413,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3275,6 +3283,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.5.3: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       eslint-config-next:
         specifier: ^15.3.2
         version: 15.3.2(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint-config-prettier:
+        specifier: ^10.1.5
+        version: 10.1.5(eslint@9.26.0(jiti@2.4.2))
       jiti:
         specifier: ^2.4.2
         version: 2.4.2
@@ -763,6 +766,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  eslint-config-prettier@10.1.5:
+    resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
 
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
@@ -2532,6 +2541,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
       - supports-color
+
+  eslint-config-prettier@10.1.5(eslint@9.26.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.26.0(jiti@2.4.2)
 
   eslint-import-resolver-node@0.3.9:
     dependencies:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,22 @@
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
+const prettierConfig = {
+  arrowParens: 'always',
+  bracketSameLine: false,
+  endOfLine: 'lf',
+  bracketSpacing: true,
+  jsxSingleQuote: false,
+  printWidth: 80,
+  objectWrap: 'preserve',
+  semi: true,
+  singleAttributePerLine: false,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+  useTabs: false,
+  plugins: [],
+};
+
+export default prettierConfig;


### PR DESCRIPTION
This pull request introduces Prettier integration into the project for consistent code formatting and updates the ESLint configuration to work seamlessly with Prettier. Additionally, it includes updates to the project dependencies and configuration files to support these changes.

### Prettier Integration:
* Added a `.prettierignore` file to specify files and directories to be ignored by Prettier, such as `node_modules/`, `public/`, and `build/` (`.prettierignore`).
* Created a `prettier.config.js` file with Prettier configuration settings, including options like `arrowParens: 'always'`, `singleQuote: true`, and `printWidth: 80` (`prettier.config.js`).
* Added a new `format` script to `package.json` for running Prettier (`package.json`).

### ESLint Integration with Prettier:
* Imported `eslint-config-prettier` into `eslint.config.ts` and added it to the ESLint configuration array to disable formatting rules that might conflict with Prettier (`eslint.config.ts`) [[1]](diffhunk://#diff-3202509a51dddde1968b20a04dfcedc90615eb6681cca0cda5f43a418a516857R8) [[2]](diffhunk://#diff-3202509a51dddde1968b20a04dfcedc90615eb6681cca0cda5f43a418a516857R41).

### Dependency Updates:
* Added `prettier` and `eslint-config-prettier` as dependencies in `package.json` (`package.json`).
* Updated `pnpm-lock.yaml` to include `prettier` and `eslint-config-prettier` with their respective versions and dependencies (`pnpm-lock.yaml`) [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR39-R47) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR770-R775) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1426-R1430) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2545-R2548) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3300-R3301).

### Project Configuration:
* Set the `type` field in `package.json` to `module` to enable ES module syntax (`package.json`).