### PR TITLE
chore(vscode): add settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}


### PR DESCRIPTION
Adds a `.vscode/settings.json` file to unify code editor development settings:
- Sets `typescript.tsdk` to use the local TS version from node_modules
- Configures Prettier as the default formatter

Ensures consistency across different dev environments and avoids global version issues.