### PR TITLE
ci(github): add vercel production deployment workflow

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,0 +1,23 @@
+name: Vercel Production Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate production deployments to Vercel. The workflow is triggered on pushes to the `main` branch and includes steps for setting up the environment, building project artifacts, and deploying them to Vercel.

### New GitHub Actions workflow for Vercel production deployment:
* `.github/workflows/deploy-production.yaml`: Added a workflow named "Vercel Production Deployment" that:
  - Sets up environment variables using GitHub secrets for Vercel organization and project IDs.
  - Runs on pushes to the `main` branch.
  - Includes steps to check out the repository, install `pnpm`, set up the Vercel CLI, pull environment information, build project artifacts, and deploy them to Vercel.